### PR TITLE
The git repo of ctags now supports context and describes for ruby

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -540,6 +540,8 @@ function! s:InitTypes() abort
     let type_ruby.kinds     = [
         \ {'short' : 'm', 'long' : 'modules',           'fold' : 0, 'stl' : 1},
         \ {'short' : 'c', 'long' : 'classes',           'fold' : 0, 'stl' : 1},
+        \ {'short' : 'd', 'long' : 'describes',         'fold' : 0, 'stl' : 1},
+        \ {'short' : 'C', 'long' : 'contexts',          'fold' : 0, 'stl' : 1},
         \ {'short' : 'f', 'long' : 'methods',           'fold' : 0, 'stl' : 1},
         \ {'short' : 'F', 'long' : 'singleton methods', 'fold' : 0, 'stl' : 1}
     \ ]


### PR DESCRIPTION
So I've added in those types. It doesn't yet display nicely, but I think that's more to do with the state of the ctags support as with the tagbar parsing of the output.

At least with this in there we don't get lots of error messages.
