### PR TITLE
Add support for Fishman Ctags (issue 225)

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1060,7 +1060,8 @@ function! s:CheckForExCtags(silent) abort
 
     let ctags_output = s:ExecuteCtags(ctags_cmd)
 
-    if v:shell_error || ctags_output !~# 'Exuberant Ctags'
+    if v:shell_error || (ctags_output !~# 'Exuberant Ctags' &&
+                        \ ctags_output !~# 'Fishman Ctags')
         let errmsg = 'Tagbar: Ctags doesn''t seem to be Exuberant Ctags!'
         let infomsg = 'GNU ctags will NOT WORK.' .
             \ ' Please download Exuberant Ctags from ctags.sourceforge.net' .
@@ -1117,7 +1118,7 @@ endfunction
 function! s:CheckExCtagsVersion(output) abort
     call s:debug('Checking Exuberant Ctags version')
 
-    if a:output =~ 'Exuberant Ctags Development'
+    if a:output =~ 'Exuberant Ctags Development' || a:output =~ 'Fishman Ctags Development'
         call s:debug("Found development version, assuming compatibility")
         return 1
     endif

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1114,13 +1114,7 @@ endfunction
 function! s:CheckExCtagsVersion(output) abort
     call s:LogDebugMessage('Checking Exuberant Ctags version')
 
-    if a:output =~ 'Exuberant Ctags Development'
-        call s:LogDebugMessage("Found development version, " .
-                             \ "assuming compatibility")
-        return 1
-    endif
-
-    if a:output =~ 'Fishman Ctags Development'
+    if a:output =~ 'Exuberant Ctags Development' || a:output =~ 'Fishman Ctags Development'
         call s:LogDebugMessage("Found development version, " .
                              \ "assuming compatibility")
         return 1

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -4,7 +4,7 @@
 " Author:      Jan Larres <jan@majutsushi.net>
 " Licence:     Vim licence
 " Website:     http://majutsushi.github.com/tagbar/
-" Version:     2.6.1
+" Version:     2.6
 " Note:        This plugin was heavily inspired by the 'Taglist' plugin by
 "              Yegappan Lakshmanan and uses a small amount of code from it.
 "
@@ -56,7 +56,6 @@ let s:options = [
     \ ['compact', 0],
     \ ['expand', 0],
     \ ['foldlevel', 99],
-    \ ['hide_nonpublic', 0],
     \ ['indent', 2],
     \ ['left', 0],
     \ ['previewwin_pos', 'topleft'],
@@ -66,7 +65,6 @@ let s:options = [
     \ ['sort', 1],
     \ ['systemenc', &encoding],
     \ ['width', 40],
-    \ ['zoomwidth', 1],
 \ ]
 
 for [opt, val] in s:options
@@ -84,13 +82,12 @@ if !exists('g:tagbar_iconchars')
 endif
 
 let s:keymaps = [
-    \ ['jump',          '<CR>'],
-    \ ['preview',       'p'],
-    \ ['previewwin',    'P'],
-    \ ['nexttag',       '<C-N>'],
-    \ ['prevtag',       '<C-P>'],
-    \ ['showproto',     '<Space>'],
-    \ ['hidenonpublic', 'v'],
+    \ ['jump',       '<CR>'],
+    \ ['preview',    'p'],
+    \ ['previewwin', 'P'],
+    \ ['nexttag',    '<C-N>'],
+    \ ['prevtag',    '<C-P>'],
+    \ ['showproto',  '<Space>'],
     \
     \ ['openfold',      ['+', '<kPlus>', 'zo']],
     \ ['closefold',     ['-', '<kMinus>', 'zc']],
@@ -101,7 +98,7 @@ let s:keymaps = [
     \ ['togglesort', 's'],
     \ ['zoomwin',    'x'],
     \ ['close',      'q'],
-    \ ['help',       ['<F1>', '?']],
+    \ ['help',       '<F1>'],
 \ ]
 
 for [map, key] in s:keymaps

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -132,4 +132,3 @@ command! -nargs=0 TagbarTogglePause   call tagbar#toggle_pause()
 
 " Modeline {{{1
 " vim: ts=8 sw=4 sts=4 et foldenable foldmethod=marker foldcolumn=1
->>>>>>> upstream/master


### PR DESCRIPTION
resolve issue 225:

    Se ha detectado un error al procesar function tagbar#ToggleWindow..<SNR>164_ToggleWindow..<SNR>164_OpenWindow..<SNR>164_Init..<SNR>164_CheckForExCtags..<SNR>164_CtagsErrMsg:
        línea   10
        Tagbar: Ctags doesn't seem to be Exuberant Ctags!
        GNU ctags will NOT WORK. Please download Exuberant Ctags from ctags.sourceforge.net and install it in a directory in your $PATH or set g:tagbar_ctags_bin.
        Executed command: "ctags --version"
        Command output:
        Fishman Ctags Development, Copyright (C) 1996-2009 Darren Hiebert
          Compiled: Oct 21 2014, 17:07:07
            Addresses: <dhiebert@users.sourceforge.net>, https://github.com/fishman/ctags
              Optional compiled features: +win32, +wildcards, +regex, +internal-sort


