### PR TITLE
Explicitly resize Tagbar window upon opening

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1780,13 +1780,16 @@ function! s:OpenWindow(flags) abort
 
     let s:window_opening = 1
     if g:tagbar_vertical == 0
-        let openpos = g:tagbar_left ? 'topleft vertical ' : 'botright vertical '
+        let mode = 'vertical '
+        let openpos = g:tagbar_left ? 'topleft ' : 'botright '
         let width = g:tagbar_width
     else
+        let mode = ''
         let openpos = g:tagbar_left ? 'leftabove ' : 'rightbelow '
         let width = g:tagbar_vertical
     endif
-    exe 'silent keepalt ' . openpos . width . 'split ' . '__Tagbar__'
+    exe 'silent keepalt ' . openpos . mode . width . 'split ' . '__Tagbar__'
+    exe 'silent ' . mode . 'resize ' . width
     unlet s:window_opening
 
     call s:InitWindow(autoclose)


### PR DESCRIPTION
This fixes an issue when Tagbar window is opened with a wrong size
after another plugin window has been opened. For example, if you open
a file, then open NERDTree plugin window and after that open Tagbar
window, then Tagbar window has a size of the file window, not the
value of 'tagbar_width' (or 'tagbar_vertical').