### PR TITLE
Fix vim-airline: Suppress status-line output when executing shell

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -3665,7 +3665,7 @@ function! s:ExecuteCtags(ctags_cmd) abort
         call s:debug(v:statusmsg)
         redraw!
     else
-        let ctags_output = system(a:ctags_cmd)
+        silent let ctags_output = system(a:ctags_cmd)
     endif
 
     if &shell =~ 'cmd\.exe'


### PR DESCRIPTION
Failing to suppress output can cause problems in some environments,
especially if the shell command fails or does something else spooky.

Example where failing to suppress the shell command causes issues with
[vim-airline](https://github.com/bling/vim-airline) with the tagbar
extension enabled:

![screenshot1](http://i.imgur.com/ciigs8C.png)

Here's another example:

![screenshot2](http://i.imgur.com/cl96sI8.png)

Both were taken using uxterm in Linux.