### PR TITLE
Added proper treat of methods in Python.

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -559,11 +559,12 @@ function! s:InitTypes() abort
     let type_python.kind2scope = {
         \ 'c' : 'class',
         \ 'f' : 'function',
-        \ 'm' : 'function'
+        \ 'm' : 'method'
     \ }
     let type_python.scope2kind = {
         \ 'class'    : 'c',
-        \ 'function' : 'f'
+        \ 'function' : 'f',
+        \ 'method'   : 'm'
     \ }
     let s:known_types.python = type_python
     let s:known_types.pyrex  = type_python


### PR DESCRIPTION
Currently, all functions or methods in tagbar are mapped to function kind.
This patch makes a use of ctags information about the type of the function, so
it will be properly mapped on the structure tree.