### PR TITLE
Display the kind (type) of the tag on the status bar.

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1400,7 +1400,7 @@ function! s:NormalTag.strfmt() abort dict
 endfunction
 
 " s:NormalTag.str() {{{3
-function! s:NormalTag.str(longsig, full) abort dict
+function! s:NormalTag.str(longsig, full, showkind) abort dict
     if a:full && self.path != ''
         let str = self.path . self.typeinfo.sro . self.name
     else
@@ -1413,6 +1413,10 @@ function! s:NormalTag.str(longsig, full) abort dict
         else
             let str .= '()'
         endif
+    elseif a:showkind
+        let str .= ' (' . 
+                    \ self.fileinfo.typeinfo.kind2scope[self.fields.kind] .
+                    \ ')'
     endif
 
     return str
@@ -4182,16 +4186,20 @@ function! tagbar#currenttag(fmt, default, ...) abort
     " Indicate that the statusline functionality is being used. This prevents
     " the CloseWindow() function from removing the autocommands.
     let s:statusline_in_use = 1
+    let longsig = 0
+    let fullpath = 0
+    let prototype = 0
+    let showkind = 0
 
     if a:0 > 0
         " also test for non-zero value for backwards compatibility
         let longsig   = a:1 =~# 's' || (type(a:1) == type(0) && a:1 != 0)
         let fullpath  = a:1 =~# 'f'
         let prototype = a:1 =~# 'p'
-    else
-        let longsig   = 0
-        let fullpath  = 0
-        let prototype = 0
+        if a:1 =~# 'k'
+            let showkind = 1
+            let fullpath = 1
+        endif
     endif
 
     if !s:Init(1)
@@ -4204,7 +4212,7 @@ function! tagbar#currenttag(fmt, default, ...) abort
         if prototype
             return tag.getPrototype(1)
         else
-            return printf(a:fmt, tag.str(longsig, fullpath))
+            return printf(a:fmt, tag.str(longsig, fullpath, showkind))
         endif
     else
         return a:default

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -93,6 +93,122 @@ let s:warnings = {
     \ 'encoding': 0
 \ }
 
+let s:singular_types = {
+            \ 'Classes': 'Class',
+            \ 'Delegates': 'Delegate',
+            \ 'Enumeration values': 'Enumeration value',
+            \ 'Enumerations': 'Enumeration',
+            \ 'Error codes': 'Error code',
+            \ 'Error domains': 'Error domain',
+            \ 'Fields': 'Field',
+            \ 'Interfaces': 'Interface',
+            \ 'JavaScript funtions': 'JavaScript function',
+            \ 'Methods': 'Method',
+            \ 'MobiLink Conn Scripts': 'MobiLink Conn Script',
+            \ 'MobiLink Properties': 'MobiLink Property',
+            \ 'MobiLink Table Scripts': 'MobiLink Table Script',
+            \ 'Properties': 'Property',
+            \ 'Signals': 'Signal',
+            \ 'Structures': 'Structure',
+            \ 'autocommand groups': 'autocommand group',
+            \ 'block data': 'block data',
+            \ 'block label': 'block label',
+            \ 'chapters': 'chapter',
+            \ 'classes': 'class',
+            \ 'commands': 'command',
+            \ 'common blocks': 'common block',
+            \ 'components': 'component',
+            \ 'constant definitions': 'constant definition',
+            \ 'constants': 'constant',
+            \ 'constructors': 'constructor',
+            \ 'cursors': 'cursor',
+            \ 'data items': 'data item',
+            \ 'defines': 'define',
+            \ 'derived types and structures': 'derived type and structure',
+            \ 'domains': 'domain',
+            \ 'entities': 'entity',
+            \ 'entry points': 'entry point',
+            \ 'enum constants': 'enum constant',
+            \ 'enum types': 'enum type',
+            \ 'enumerations': 'enumeration',
+            \ 'enumerators': 'enumerator',
+            \ 'enums': 'enum',
+            \ 'events': 'event',
+            \ 'exception declarations': 'exception declaration',
+            \ 'exceptions': 'exception',
+            \ 'features': 'feature',
+            \ 'fields': 'field',
+            \ 'file descriptions': 'file description',
+            \ 'formats': 'format',
+            \ 'fragments': 'fragment',
+            \ 'function definitions': 'function definition',
+            \ 'functions': 'function',
+            \ 'functor definitions': 'functor definition',
+            \ 'global variables': 'global variable',
+            \ 'group items': 'group item',
+            \ 'imports': 'import',
+            \ 'includes': 'include',
+            \ 'indexes': 'index',
+            \ 'interfaces': 'interface',
+            \ 'javascript functions': 'JavaScript function',
+            \ 'labels': 'label',
+            \ 'macro definitions': 'macro definition',
+            \ 'macros': 'macro',
+            \ 'maps': 'map',
+            \ 'members': 'member',
+            \ 'methods': 'method',
+            \ 'modules or functors': 'module or function',
+            \ 'modules': 'module',
+            \ 'mxtags': 'mxtag',
+            \ 'named anchors': 'named anchor',
+            \ 'namelists': 'namelist',
+            \ 'namespaces': 'namespace',
+            \ 'net data types': 'net data type',
+            \ 'packages': 'package',
+            \ 'paragraphs': 'paragraph',
+            \ 'parts': 'part',
+            \ 'patterns': 'pattern',
+            \ 'ports': 'port',
+            \ 'procedures': 'procedure',
+            \ 'program ids': 'program id',
+            \ 'programs': 'program',
+            \ 'projects': 'project',
+            \ 'properties': 'property',
+            \ 'prototypes': 'prototype',
+            \ 'publications': 'publication',
+            \ 'record definitions': 'record definition',
+            \ 'record fields': 'record field',
+            \ 'records': 'record',
+            \ 'register data types': 'register data type',
+            \ 'sections': 'section',
+            \ 'services': 'services',
+            \ 'sets': 'sets',
+            \ 'signature declarations': 'signature declaration',
+            \ 'singleton methods': 'singleton method',
+            \ 'slots': 'slot',
+            \ 'structs': 'struct',
+            \ 'structure declarations': 'structure declaration',
+            \ 'structure fields': 'structure field',
+            \ 'subparagraphs': 'subparagraph',
+            \ 'subroutines': 'subroutine',
+            \ 'subsections': 'subsection',
+            \ 'subsubsections': 'subsubsection',
+            \ 'subtypes': 'subtype',
+            \ 'synonyms': 'synonym',
+            \ 'tables': 'table',
+            \ 'targets': 'target',
+            \ 'tasks': 'task',
+            \ 'triggers': 'trigger',
+            \ 'type definitions': 'type definition',
+            \ 'type names': 'type name',
+            \ 'typedefs': 'typedef',
+            \ 'types': 'type',
+            \ 'unions': 'union',
+            \ 'value bindings': 'value binding',
+            \ 'variables': 'variable',
+            \ 'views': 'view',
+            \ 'vimball filenames': 'vimball filename'}
+
 " s:Init() {{{2
 function! s:Init(silent) abort
     if s:checked_ctags == 2 && a:silent
@@ -1414,9 +1530,14 @@ function! s:NormalTag.str(longsig, full, showkind) abort dict
             let str .= '()'
         endif
     elseif a:showkind
-        let str .= ' (' . 
-                    \ self.fileinfo.typeinfo.kind2scope[self.fields.kind] .
-                    \ ')'
+        let kind = tag.fields.kind
+        if kind == ''
+            return str
+        endif
+
+        let typeinfo = tag.fileinfo.typeinfo
+        let plural = typeinfo.kinds[typeinfo.kinddict[kind]].long
+        let str .= ' (' . s:singular_types[plural] . ')'
     endif
 
     return str

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -828,6 +828,9 @@ tagbar#currenttag({format}, {default} [, {flags}])
     'p'   Display the raw prototype instead of the parsed tag. This can be
           useful in cases where ctags doesn't report some information, like
           the signature. Note that this can get quite long.
+    'k'   This is essentially the same as in 'f' flag - it will display the 
+          full hierarchy of the tag, and additionally will provide the 
+          information of the kind of the tag.
 
     For example, if you put the following into your statusline: >
         %{tagbar#currenttag('[%s] ','')}

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -828,8 +828,8 @@ tagbar#currenttag({format}, {default} [, {flags}])
     'p'   Display the raw prototype instead of the parsed tag. This can be
           useful in cases where ctags doesn't report some information, like
           the signature. Note that this can get quite long.
-    'k'   This is essentially the same as in 'f' flag - it will display the 
-          full hierarchy of the tag, and additionally will provide the 
+    'k'   This is essentially the same as in 'f' flag - it will display the
+          full hierarchy of the tag, and additionally will provide the
           information of the kind of the tag.
 
     For example, if you put the following into your statusline: >


### PR DESCRIPTION
Besides the usual tag hierarchy, type of the tag would be provided.

This patch is an attempt to provide some more information to the status bar. It will allow to the user to use the tagbar#currenttag function to display tag kind/type (class, function, method, etc) next to the full tag path using 'k' flag.

Note, that this pull request is an alternative version to #308
