### PR TITLE
Additional function for displaying type of a current tag.

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -159,6 +159,7 @@ let s:singular_types = {
             \ 'namespaces': 'namespace',
             \ 'net data types': 'net data type',
             \ 'packages': 'package',
+            \ 'package': 'package',
             \ 'paragraphs': 'paragraph',
             \ 'parts': 'part',
             \ 'patterns': 'pattern',

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -122,6 +122,7 @@ let s:singular_types = {
             \ 'domains': 'domain',
             \ 'entities': 'entity',
             \ 'entry points': 'entry point',
+            \ 'embedded': 'embedded',
             \ 'enum constants': 'enum constant',
             \ 'enum types': 'enum type',
             \ 'enumerations': 'enumeration',

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -87,6 +87,122 @@ let s:warnings = {
     \ 'encoding': 0
 \ }
 
+let s:singular_types = {
+            \ 'Classes': 'Class',
+            \ 'Delegates': 'Delegate',
+            \ 'Enumeration values': 'Enumeration value',
+            \ 'Enumerations': 'Enumeration',
+            \ 'Error codes': 'Error code',
+            \ 'Error domains': 'Error domain',
+            \ 'Fields': 'Field',
+            \ 'Interfaces': 'Interface',
+            \ 'JavaScript funtions': 'JavaScript function',
+            \ 'Methods': 'Method',
+            \ 'MobiLink Conn Scripts': 'MobiLink Conn Script',
+            \ 'MobiLink Properties': 'MobiLink Property',
+            \ 'MobiLink Table Scripts': 'MobiLink Table Script',
+            \ 'Properties': 'Property',
+            \ 'Signals': 'Signal',
+            \ 'Structures': 'Structure',
+            \ 'autocommand groups': 'autocommand group',
+            \ 'block data': 'block data',
+            \ 'block label': 'block label',
+            \ 'chapters': 'chapter',
+            \ 'classes': 'class',
+            \ 'commands': 'command',
+            \ 'common blocks': 'common block',
+            \ 'components': 'component',
+            \ 'constant definitions': 'constant definition',
+            \ 'constants': 'constant',
+            \ 'constructors': 'constructor',
+            \ 'cursors': 'cursor',
+            \ 'data items': 'data item',
+            \ 'defines': 'define',
+            \ 'derived types and structures': 'derived type and structure',
+            \ 'domains': 'domain',
+            \ 'entities': 'entity',
+            \ 'entry points': 'entry point',
+            \ 'enum constants': 'enum constant',
+            \ 'enum types': 'enum type',
+            \ 'enumerations': 'enumeration',
+            \ 'enumerators': 'enumerator',
+            \ 'enums': 'enum',
+            \ 'events': 'event',
+            \ 'exception declarations': 'exception declaration',
+            \ 'exceptions': 'exception',
+            \ 'features': 'feature',
+            \ 'fields': 'field',
+            \ 'file descriptions': 'file description',
+            \ 'formats': 'format',
+            \ 'fragments': 'fragment',
+            \ 'function definitions': 'function definition',
+            \ 'functions': 'function',
+            \ 'functor definitions': 'functor definition',
+            \ 'global variables': 'global variable',
+            \ 'group items': 'group item',
+            \ 'imports': 'import',
+            \ 'includes': 'include',
+            \ 'indexes': 'index',
+            \ 'interfaces': 'interface',
+            \ 'javascript functions': 'JavaScript function',
+            \ 'labels': 'label',
+            \ 'macro definitions': 'macro definition',
+            \ 'macros': 'macro',
+            \ 'maps': 'map',
+            \ 'members': 'member',
+            \ 'methods': 'method',
+            \ 'modules or functors': 'module or function',
+            \ 'modules': 'module',
+            \ 'mxtags': 'mxtag',
+            \ 'named anchors': 'named anchor',
+            \ 'namelists': 'namelist',
+            \ 'namespaces': 'namespace',
+            \ 'net data types': 'net data type',
+            \ 'packages': 'package',
+            \ 'paragraphs': 'paragraph',
+            \ 'parts': 'part',
+            \ 'patterns': 'pattern',
+            \ 'ports': 'port',
+            \ 'procedures': 'procedure',
+            \ 'program ids': 'program id',
+            \ 'programs': 'program',
+            \ 'projects': 'project',
+            \ 'properties': 'property',
+            \ 'prototypes': 'prototype',
+            \ 'publications': 'publication',
+            \ 'record definitions': 'record definition',
+            \ 'record fields': 'record field',
+            \ 'records': 'record',
+            \ 'register data types': 'register data type',
+            \ 'sections': 'section',
+            \ 'services': 'services',
+            \ 'sets': 'sets',
+            \ 'signature declarations': 'signature declaration',
+            \ 'singleton methods': 'singleton method',
+            \ 'slots': 'slot',
+            \ 'structs': 'struct',
+            \ 'structure declarations': 'structure declaration',
+            \ 'structure fields': 'structure field',
+            \ 'subparagraphs': 'subparagraph',
+            \ 'subroutines': 'subroutine',
+            \ 'subsections': 'subsection',
+            \ 'subsubsections': 'subsubsection',
+            \ 'subtypes': 'subtype',
+            \ 'synonyms': 'synonym',
+            \ 'tables': 'table',
+            \ 'targets': 'target',
+            \ 'tasks': 'task',
+            \ 'triggers': 'trigger',
+            \ 'type definitions': 'type definition',
+            \ 'type names': 'type name',
+            \ 'typedefs': 'typedef',
+            \ 'types': 'type',
+            \ 'unions': 'union',
+            \ 'value bindings': 'value binding',
+            \ 'variables': 'variable',
+            \ 'views': 'view',
+            \ 'vimball filenames': 'vimball filename'}
+
 " s:Init() {{{2
 function! s:Init(silent) abort
     if s:checked_ctags == 2 && a:silent
@@ -3502,6 +3618,29 @@ endfunction
 " tagbar#inspect() {{{2
 function! tagbar#inspect(var) abort
     return get(s:, a:var)
+endfunction
+
+" tagbar#currenttagtype() {{{2
+function! tagbar#currenttagtype(fmt, default) abort
+    " Indicate that the statusline functionality is being used. This prevents
+    " the CloseWindow() function from removing the autocommands.
+    let s:statusline_in_use = 1
+    let kind = ''
+    let tag = s:GetNearbyTag(0, 1)
+
+    if empty(tag)
+        return a:default
+    endif
+
+    let kind = tag.fields.kind
+    if kind ==# ''
+        return a:default
+    endif
+
+    let typeinfo = tag.fileinfo.typeinfo
+    let plural = typeinfo.kinds[typeinfo.kinddict[kind]].long
+    let singular = s:singular_types[plural]
+    return printf(a:fmt, singular)
 endfunction
 
 " Modeline {{{1

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -910,6 +910,17 @@ tagbar#currenttag({format}, {default} [, {flags}])
         %{tagbar#currenttag('[%s] ','')}
 <   then the function "myfunc" will be shown as "[myfunc()] ".
 
+Additionally you can show the kind (type) of the current tag, using following
+function:
+
+tagbar#currenttagtype({format}, {default})
+    {format} and {default} are treated in the same way as for
+    tagbar#currenttag function.
+
+    Altering previous example, like below: >
+        %{tagbar#currenttag('[%s] ','')}\ %{tagbar#currenttagtype("(%s) ", '')
+<   the function "myfunc" will be shown as "[myfunc()] (function)".
+
 Note that if there is an error when processing the current file no error
 message will be shown in order to not disrupt the statusline. If the function
 doesn't seem to work right open the Tagbar window to see any error messages.


### PR DESCRIPTION
Introducing small function for displaying type (kind) of a current tag. Useful
for putting it in the status bar.

This is an alternative version of the #307 - instead expanding the tagbar#currenttag function, new one (tagbar#currenttagtype) was added so the user can influence a way how it will be displayed on the statusbar (or anywhere else).
