### PR TITLE
Silent option

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -994,7 +994,9 @@ function! s:CreateAutocommands() abort
 
     augroup TagbarAutoCmds
         autocmd!
-        autocmd CursorHold __Tagbar__ call s:ShowPrototype(1)
+        if !g:tagbar_silent
+            autocmd CursorHold __Tagbar__ call s:ShowPrototype(1)
+        endif
         autocmd WinEnter   __Tagbar__ call s:SetStatusLine('current')
         autocmd WinLeave   __Tagbar__ call s:SetStatusLine('noncurrent')
 

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -709,6 +709,18 @@ default statusline:
         let g:tagbar_status_func = 'TagbarStatusFunc'
 <
 
+                                                           *g:tagbar_silent*
+g:tagbar_silent~
+Default: 0
+
+By default if the cursor is over a tag in the tagbar window, information
+about the tag is echoed out. Set this option to disable that behavior.
+
+Example:
+>
+        let g:tagbar_silent = 1
+<
+
 ------------------------------------------------------------------------------
 HIGHLIGHT COLOURS                                           *tagbar-highlight*
 

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -74,6 +74,7 @@ function! s:setup_options() abort
         \ ['vertical', 0],
         \ ['width', 40],
         \ ['zoomwidth', 1],
+        \ ['silent', 0],
     \ ]
 
     for [opt, val] in options


### PR DESCRIPTION
If the silent option is set, tagbar doesn't echo out information about
the tag the cursor is on in the tagbar window.