### PR TITLE
flags argument added to functions responsible for window toggling

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1775,7 +1775,7 @@ endfunction
 
 " Window management {{{1
 " s:ToggleWindow() {{{2
-function! s:ToggleWindow() abort
+function! s:ToggleWindow(flags) abort
     call s:debug('ToggleWindow called')
 
     let tagbarwinnr = bufwinnr(s:TagbarBufName())
@@ -1784,7 +1784,7 @@ function! s:ToggleWindow() abort
         return
     endif
 
-    call s:OpenWindow('')
+    call s:OpenWindow(a:flags)
 
     call s:debug('ToggleWindow finished')
 endfunction
@@ -4242,8 +4242,9 @@ endfunction
 " Autoload functions {{{1
 
 " Wrappers {{{2
-function! tagbar#ToggleWindow() abort
-    call s:ToggleWindow()
+function! tagbar#ToggleWindow(...) abort
+    let flags = a:0 > 0 ? a:1 : ''
+    call s:ToggleWindow(flags)
 endfunction
 
 function! tagbar#OpenWindow(...) abort


### PR DESCRIPTION
It would be great to have the ability to pass custom flags to OpenWindow function from ToggleWindow function. In this case users will be able to customize Tagbar behaviour in "toggle" mode. For example in my configuration I want:
* Tagbar be toggled by pressing the same key (<C-2> in my case);
* cursor be moved to Tagbar window when Tagbar window becomes visible;
* Tagbar window automatically be closed on tag selection.

Having changes from this pull request I can setup Tagbar behaviour I want:
```
command! -nargs=0 TagbarToggleFocusAutoClose call tagbar#ToggleWindow('fcj')
nmap <C-2> :TagbarToggleFocusAutoClose<CR>
```
