### PR TITLE
Add note about Universal ctags

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ creates the tags it needs on-the-fly in-memory without creating any files.
 ## Dependencies
 
 [Vim 7.0](http://www.vim.org/) (But see note below)  
-[Exuberant ctags 5.5](http://ctags.sourceforge.net/)
+[Exuberant ctags 5.5](http://ctags.sourceforge.net/) or 
+[Universal Ctags](https://ctags.io/) which is a fork of exuberant ctags 
+continuing the development. 
 
 ## Installation
 


### PR DESCRIPTION
I found that exhuberant tag seem abandonned for long time (last version is from 2009), however a fork as been made called Universal ctags, it seems to work great, correct few bugs and add additional langages. I think it could be useful to advice other users to use it. 