### PR TITLE
Fix scopes for ruby

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -635,9 +635,10 @@ function! s:InitTypes() abort
     \ ]
     let type_ruby.sro        = '.'
     let type_ruby.kind2scope = {
+        \ 'm' : 'module',
         \ 'c' : 'class',
-        \ 'm' : 'class',
-        \ 'f' : 'class'
+        \ 'f' : 'method',
+        \ 'F' : 'singleton method'
     \ }
     let type_ruby.scope2kind = {
         \ 'class' : 'c'


### PR DESCRIPTION
Currently scope is always class. This change fixes it

### before
![image](https://cloud.githubusercontent.com/assets/3197608/23885139/ada9bc3c-08b4-11e7-93a2-6b2827d309ff.png)

### after
![image](https://cloud.githubusercontent.com/assets/3197608/23885058/1af24d0a-08b4-11e7-90ff-4f66cb620f87.png)
