### PR TITLE
compatibility with phpctags

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1245,6 +1245,11 @@ function! s:CheckExCtagsVersion(output) abort
         return 1
     endif
 
+    if a:output =~ 'Exuberant Ctags compatiable PHP enhancement'
+        call s:debug("Found phpctags, assuming compatibility")
+        return 1
+    endif
+
     if a:output =~ 'Exuberant Ctags Development'
         call s:debug("Found development version, assuming compatibility")
         return 1


### PR DESCRIPTION
https://github.com/techlivezheng/phpctags

phpctags --version output :

Version: 0.5.1

Exuberant Ctags compatiable PHP enhancement, Copyright (C) 2012 Techlive Zheng
Addresses: <techlivezheng@gmail.com>, https://github.com/techlivezheng/phpctags
