### PR TITLE
Add PHP scopes and additional kinds

### DIFF
--- a/autoload/tagbar/typedefs/uctags.vim
+++ b/autoload/tagbar/typedefs/uctags.vim
@@ -426,13 +426,25 @@ function! tagbar#typedefs#uctags#init(supported_types) abort
     let type_php = tagbar#prototypes#typeinfo#new()
     let type_php.ctagstype = 'php'
     let type_php.kinds     = [
-        \ {'short' : 'i', 'long' : 'interfaces',           'fold' : 0, 'stl' : 1},
-        \ {'short' : 'c', 'long' : 'classes',              'fold' : 0, 'stl' : 1},
+        \ {'short' : 'n', 'long' : 'namespaces',           'fold' : 0, 'stl' : 0},
+        \ {'short' : 'a', 'long' : 'use aliases',          'fold' : 1, 'stl' : 0},
         \ {'short' : 'd', 'long' : 'constant definitions', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'i', 'long' : 'interfaces',           'fold' : 0, 'stl' : 1},
+        \ {'short' : 't', 'long' : 'traits',               'fold' : 0, 'stl' : 1},
+        \ {'short' : 'c', 'long' : 'classes',              'fold' : 1, 'stl' : 1},
+        \ {'short' : 'v', 'long' : 'variables',            'fold' : 1, 'stl' : 0},
         \ {'short' : 'f', 'long' : 'functions',            'fold' : 0, 'stl' : 1},
-        \ {'short' : 'v', 'long' : 'variables',            'fold' : 0, 'stl' : 0},
-        \ {'short' : 'j', 'long' : 'javascript functions', 'fold' : 0, 'stl' : 1}
+        \ {'short' : 'j', 'long' : 'javascript functions', 'fold' : 0, 'stl' : 1},
     \ ]
+    let type_php.sro        = '\\\\'
+    let type_php.kind2scope = {
+        \ 'c' : 'class',
+        \ 'n' : 'namespace'
+    \ }
+    let type_php.scope2kind = {
+        \ 'class'    : 'c',
+        \ 'namespace' : 'n'
+    \ }
     let types.php = type_php
     " Python {{{1
     let type_python = tagbar#prototypes#typeinfo#new()

--- a/autoload/tagbar/typedefs/uctags.vim
+++ b/autoload/tagbar/typedefs/uctags.vim
@@ -431,7 +431,7 @@ function! tagbar#typedefs#uctags#init(supported_types) abort
         \ {'short' : 'd', 'long' : 'constant definitions', 'fold' : 0, 'stl' : 0},
         \ {'short' : 'i', 'long' : 'interfaces',           'fold' : 0, 'stl' : 1},
         \ {'short' : 't', 'long' : 'traits',               'fold' : 0, 'stl' : 1},
-        \ {'short' : 'c', 'long' : 'classes',              'fold' : 1, 'stl' : 1},
+        \ {'short' : 'c', 'long' : 'classes',              'fold' : 0, 'stl' : 1},
         \ {'short' : 'v', 'long' : 'variables',            'fold' : 1, 'stl' : 0},
         \ {'short' : 'f', 'long' : 'functions',            'fold' : 0, 'stl' : 1},
         \ {'short' : 'j', 'long' : 'javascript functions', 'fold' : 0, 'stl' : 1},
@@ -439,11 +439,15 @@ function! tagbar#typedefs#uctags#init(supported_types) abort
     let type_php.sro        = '\\\\'
     let type_php.kind2scope = {
         \ 'c' : 'class',
-        \ 'n' : 'namespace'
+        \ 'n' : 'namespace',
+        \ 'i' : 'interface',
+        \ 't' : 'trait',
     \ }
     let type_php.scope2kind = {
-        \ 'class'    : 'c',
-        \ 'namespace' : 'n'
+        \ 'class'     : 'c',
+        \ 'namespace' : 'n',
+        \ 'interface' : 'i',
+        \ 'trait'     : 't',
     \ }
     let types.php = type_php
     " Python {{{1


### PR DESCRIPTION


Added scopes, so tagbar will show the following hierarchy:
```
  namespace
    subnamespace
      ...
        class
	  property (variable)
	  ...
	  method
	  ...
```

![screenshot fri aug 18 2017 03 29 46 gmt 0300 eest 1913x971](https://user-images.githubusercontent.com/57403/29439372-d4d1c516-83c5-11e7-97d0-d8d8fd7d60b9.png)

Additional kinds added (basically the same as #283):
 * namespaces
 * use aliases (imports)
 * traits