### PR TITLE
support NuWeb

### DIFF
--- a/autoload/tagbar/types/ctags.vim
+++ b/autoload/tagbar/types/ctags.vim
@@ -590,6 +590,7 @@ function! tagbar#types#ctags#init(supported_types) abort
     \ }
     let type_tex.sort = 0
     let types.tex = type_tex
+    let types.nuweb = type_tex
     " Vala {{{1
     " Vala is supported by the ctags fork provided by Anjuta, so only add the
     " type if the fork is used to prevent error messages otherwise

--- a/autoload/tagbar/types/uctags.vim
+++ b/autoload/tagbar/types/uctags.vim
@@ -674,6 +674,7 @@ function! tagbar#types#uctags#init(supported_types) abort
     \ }
     let type_tex.sort = 0
     let types.tex = type_tex
+    let types.nuweb = type_tex
     " Vala {{{1
     " Vala is supported by the ctags fork provided by Anjuta, so only add the
     " type if the fork is used to prevent error messages otherwise


### PR DESCRIPTION
Support [nuweb](http://nuweb.sourceforge.net). I simply force Tagbar to load Latex filetype. 

P.s: to properly run with ctags, append the following line to `~/.ctags`:

```
--langmap=Tex:+.nw
```