### PR TITLE
fixed encoding bug of balloon

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -3182,7 +3182,15 @@ function! TagbarBalloonExpr() abort
         return ''
     endif
 
-    return taginfo.getPrototype(0)
+    let prototype = taginfo.getPrototype(0)
+    if has('multi_byte')
+        if g:tagbar_systemenc != &encoding
+            let prototype = iconv(prototype, &encoding, g:tagbar_systemenc)
+        elseif $LANG != ''
+            let prototype = iconv(prototype, &encoding, $LANG)
+        endif
+    endif
+    return prototype
 endfunction
 
 " Autoload functions {{{1


### PR DESCRIPTION
Balloon show garbled text in gvim when tag prototype include cjk encoded character and system_encoding not equal to &encoding.
![image](https://user-images.githubusercontent.com/10803208/30531968-3d4cd9c4-9c84-11e7-8ff6-60cee6ac198d.png)
