### PR TITLE
Add g:tagbar_ctags_options

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1086,7 +1086,14 @@ function! s:ExecuteCtagsOnFile(fname, realfname, typeinfo) abort
         "intended to be in an argument, spaces in a single ctag_args
         "string would be ambiguous. Is the space an argument separator
         "or to be included in the argument
-        let ctags_args  = [ '-f',
+        let ctags_args = []
+        if exists('g:tagbar_ctags_options')
+            for value in g:tagbar_ctags_options
+                call add(ctags_args, '--options='.value)
+            endfor
+        fi
+        let ctags_args  = ctags_args + [
+                          \ '-f',
                           \ '-',
                           \ '--format=2',
                           \ '--excmd=pattern',
@@ -1096,10 +1103,6 @@ function! s:ExecuteCtagsOnFile(fname, realfname, typeinfo) abort
                           \ '--sort=no',
                           \ '--append=no'
                           \ ]
-        if exists('g:tagbar_ctags_options')
-            let ctags_args  = add(ctags_args,
-                \ '--options='.g:tagbar_ctags_options)
-        fi
 
         " verbose if debug enabled
         if tagbar#debug#enabled()

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1096,6 +1096,10 @@ function! s:ExecuteCtagsOnFile(fname, realfname, typeinfo) abort
                           \ '--sort=no',
                           \ '--append=no'
                           \ ]
+        if exists('g:tagbar_ctags_options')
+            let ctags_args  = add(ctags_args,
+                \ '--options='.g:tagbar_ctags_options)
+        fi
 
         " verbose if debug enabled
         if tagbar#debug#enabled()

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -390,6 +390,22 @@ Example:
         let g:tagbar_ctags_bin = 'C:\Ctags5.8\ctags.exe'
 <
 
+                                                      *g:tagbar_ctags_options*
+g:tagbar_ctags_options
+Default: undefined
+
+Use this option to specify the '--options' flag for the ctags executable,
+reading in an additional ctags configuration file. This is similar to the
+deffile key for tagbar type extensions, see |tagbar-extend|, but acts
+globally.
+
+Example:
+>
+        let g:tagbar_ctags_options = split(&rtp,",")[0].'/ctags.cnf'
+
+This makes sure that ctags is called with options from ~/.vim/ctags.cnf
+
+
                                                                *g:tagbar_left*
 g:tagbar_left~
 Default: 0
@@ -1269,7 +1285,9 @@ ctags manually execute the following command in a terminal:
         ctags -f - --format=2 --excmd=pattern --extra= --fields=nksaSmt myfile
 <
 If you set the |g:tagbar_ctags_bin| variable you probably have to use the same
-value here instead of simply "ctags".
+value here instead of simply "ctags". Also, if you use
+|:tagbar_ctags_options|, you should include the equivalent --options flag in
+the call to ctags.
 
 If something more fundamental isn't working right then try running the
 |:messages| command to see if Tagbar printed any error messages that might

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -394,16 +394,20 @@ Example:
 g:tagbar_ctags_options
 Default: undefined
 
-Use this option to specify the '--options' flag for the ctags executable,
-reading in an additional ctags configuration file. This is similar to the
-deffile key for tagbar type extensions, see |tagbar-extend|, but acts
-globally.
+Use this option to specify a list of filenames to pass to ctags with the
+'--options' flag.  This is similar to the deffile key for tagbar type
+extensions, see |tagbar-extend|, but acts globally. The special value 'NONE'
+as the first entry disables reading of the default configuration files (e.g.
+~/.ctags). Without this, if ~/.ctags and other files listed in
+g:tagbar_ctags_options include some of the same patterns, tagbar might show
+duplicate entries.
 
 Example:
 >
-        let g:tagbar_ctags_options = split(&rtp,",")[0].'/ctags.cnf'
+        let g:tagbar_ctags_options = ['NONE', split(&rtp,",")[0].'/ctags.cnf']
 
-This makes sure that ctags is called with options from ~/.vim/ctags.cnf
+This causes ctags to use settings from ~/.vim/ctags.cnf, ignoring other
+configuration files.
 
 
                                                                *g:tagbar_left*


### PR DESCRIPTION
This adds an option `g:tagbar_ctags_options`. If defined, its values are passed to `ctags` via `--options`. That is, it allows the tagbar plugin to use a custom `ctags` configuration file. It provides globally what the `deffile` key in `tagbar-extend` provides for specific file types.

Personally, I like to have my vim configuration as self-contained as possible, so I have a file `ctags.cnf` in `~/.vim/`. Then, I only have to pull my vim configuration to a new computer and can expect the tagbar plugin to work, without also having to worry about installing `~/.ctags`.

The patch updates both the tagbar plugin and the help file to document this new feature.