### PR TITLE
Add asciidoc support

### DIFF
--- a/autoload/tagbar/types/uctags.vim
+++ b/autoload/tagbar/types/uctags.vim
@@ -47,6 +47,37 @@ function! tagbar#types#uctags#init(supported_types) abort
         \ {'short' : 't', 'long' : 'targets',    'fold' : 0, 'stl' : 1}
     \ ]
     let types.ant = type_ant
+    " Asciidoc {{{1
+    let type_asciidoc = tagbar#prototypes#typeinfo#new()
+    let type_asciidoc.ctagstype = 'asciidoc'
+    let type_asciidoc.kinds     = [
+        \ {'short' : 'c', 'long' : 'chapter',       'fold' : 0, 'stl' : 1},
+        \ {'short' : 's', 'long' : 'section',       'fold' : 0, 'stl' : 1},
+        \ {'short' : 'S', 'long' : 'subsection',    'fold' : 0, 'stl' : 1},
+        \ {'short' : 't', 'long' : 'subsubsection', 'fold' : 0, 'stl' : 1},
+        \ {'short' : 'T', 'long' : 'paragraph',     'fold' : 0, 'stl' : 1},
+        \ {'short' : 'u', 'long' : 'subparagraph',  'fold' : 0, 'stl' : 1},
+        \ {'short' : 'a', 'long' : 'anchor',        'fold' : 0, 'stl' : 0}
+    \ ]
+    let type_asciidoc.sro        = '""'
+    let type_asciidoc.kind2scope = {
+        \ 'c' : 'chapter',
+        \ 's' : 'section',
+        \ 'S' : 'subsection',
+        \ 't' : 'subsubsection',
+        \ 'T' : 'l4subsection',
+        \ 'u' : 'l5subsection'
+    \ }
+    let type_asciidoc.scope2kind = {
+        \ 'chapter' : 'c',
+        \ 'section' : 's',
+        \ 'subsection' : 'S',
+        \ 'subsubsection' : 't',
+        \ 'l4subsection' : 'T',
+        \ 'l5subsection' : 'u'
+    \ }
+    let type_asciidoc.sort = 0
+    let types.asciidoc = type_asciidoc
     " Asm {{{1
     let type_asm = tagbar#prototypes#typeinfo#new()
     let type_asm.ctagstype = 'asm'


### PR DESCRIPTION
universal ctags supports asciidoc (apart from [a bug that may leave out the first level heading](https://github.com/universal-ctags/ctags/issues/2061)).

This PR adds asciidoc support to tagbar.

However it is not perfect. The output is not what I would expect it to be. I compare it with the support for latex which is _very_ similar.

![adoc_vs_tex](https://user-images.githubusercontent.com/36069345/54999713-26400600-4fd1-11e9-90e6-7e7a41a3f802.png)

![adoc](https://user-images.githubusercontent.com/36069345/54999915-9f3f5d80-4fd1-11e9-9aa6-138ce8155d31.png)
![tex](https://user-images.githubusercontent.com/36069345/54999933-a6ff0200-4fd1-11e9-93a3-6a70cfcc4b17.png)

As you can see the items for the latex file are correctly structured in a full tree structure.

But the items for the asciidoc file only contain the direct children. And those children are then displayed again at the top level.

Also the anchors in the asciidoc file are displayed only in the sections they are defined in whereas they are in a separate top level structure "labels" for the latex file.

I actually don't expect this to be the result of the aforementioned bug, since then I would expect only a problem with the level 1 headings (that are not visible, as expected).

Any help to fixing this is appreciated!