### PR TITLE
Discover the universal-ctags binary

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -398,6 +398,7 @@ function! s:CheckForExCtags(silent) abort
         let ctagsbins += ['ctags']
         let ctagsbins += ['ctags.exe']
         let ctagsbins += ['tags']
+        let ctagsbins += ['universal-ctags']
         for ctags in ctagsbins
             if executable(ctags)
                 let g:tagbar_ctags_bin = ctags


### PR DESCRIPTION
At least in the openSUSE package for `universal-ctags` it is not installed as `ctags`