### PR TITLE
Test for basic functionality in (n)vim using CI job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,33 @@
+name: Check
+
+on: [push, pull_request]
+
+jobs:
+  check:
+    strategy:
+      fail-fast: false
+      matrix:
+        vimFlavor: ["vim", "nvim"]
+        tagsProvider: ["exuberant-ctags", "universal-tags"]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Install ${{ matrix.tagsProvider }}
+      run: |
+        case ${{ matrix.tagsProvider }} in
+          exuberant-*) sudo apt-get install ctags ;;
+          universal-*) sudo snap install universal-ctags ;;
+        esac
+    - name: Install ${{ matrix.vimFlavor }}
+      if: matrix.vimFlavor == 'nvim'
+      run: |
+        sudo add-apt-repository ppa:neovim-ppa/unstable
+        sudo apt-get update
+        sudo apt-get install neovim
+    - name: Review ctags version
+      run: ctags --version
+    - name: Review ${{ matrix.vimFlavor }} version
+      run: ${{ matrix.vimFlavor }} --version
+    - name: Load plugin and try OpenWindow()
+      run: ${{ matrix.vimFlavor }} -i NONE "+set rtp+=$(pwd)" "+call tagbar#OpenWindow() | q" "+cq" plugin/tagbar.vim

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,12 +22,13 @@ jobs:
     - name: Install ${{ matrix.vimFlavor }}
       if: matrix.vimFlavor == 'nvim'
       run: |
-        sudo add-apt-repository ppa:neovim-ppa/unstable
+        sudo add-apt-repository universe
         sudo apt-get update
         sudo apt-get install neovim
     - name: Review ctags version
       run: ctags --version
     - name: Review ${{ matrix.vimFlavor }} version
       run: ${{ matrix.vimFlavor }} --version
-    - name: Load plugin and try OpenWindow()
-      run: ${{ matrix.vimFlavor }} -i NONE "+set rtp+=$(pwd)" "+call tagbar#OpenWindow() | q" "+cq" plugin/tagbar.vim
+    - name: "Try tagbar#OpenWindow()"
+      run: |
+        ${{ matrix.tagsProvider == 'nvim' && 'nvim -i NONE -u /dev/null --headless' || 'vim -i NONE' }} "+set rtp+=$(pwd)" "+call tagbar#OpenWindow() | q" "+cq" plugin/tagbar.vim

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Tagbar: a class outline viewer for Vim
 
 [![Vint](https://github.com/majutsushi/tagbar/workflows/Vint/badge.svg)](https://github.com/majutsushi/tagbar/actions?workflow=Vint)
+[![Check](https://github.com/majutsushi/tagbar/workflows/Check/badge.svg)](https://github.com/majutsushi/tagbar/actions?workflow=Check)
 
 ## What Tagbar is
 


### PR DESCRIPTION
Another step towards #551.

This doesn't test anything fancier than confirming that `TagbarOpen` doesn't throw an error in `vim` & `nvim` using `ctags` and `uctags`, but that's something to start with.