### PR TITLE
Arrange (u)ctag argument order to not clobber others

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1100,6 +1100,14 @@ function! s:ExecuteCtagsOnFile(fname, realfname, typeinfo) abort
                 call add(ctags_args, '--options='.value)
             endfor
         endif
+
+        " universal-ctags deprecated this argument name
+        if s:ctags_is_uctags
+            let ctags_args += [ '--extras=' ]
+        else
+            let ctags_args += [ '--extra=' ]
+        endif
+
         let ctags_args  = ctags_args + [
                           \ '-f',
                           \ '-',
@@ -1110,13 +1118,6 @@ function! s:ExecuteCtagsOnFile(fname, realfname, typeinfo) abort
                           \ '--sort=no',
                           \ '--append=no'
                           \ ]
-
-        " universal-ctags deprecated this argument name
-        if s:ctags_is_uctags
-            let ctags_args += [ '--extras=' ]
-        else
-            let ctags_args += [ '--extra=' ]
-        endif
 
         " verbose if debug enabled
         if tagbar#debug#enabled()


### PR DESCRIPTION
Fixes #559.

Argument order matters. In trying to fix the ctags needing `--extra` and universal ctags wanting `--extras` I inadvertently messed up the order and one of the other flags actually conflicts with this. We should probably be setting `--extras=F` instead, but we should probably just have two full sets of options optimized for each. Since I don't have an original ctags around to test with at the moment I'm pushing this through so at least expected behavior comes back.