### PR TITLE
Fall back to using bourne shell if $SHELL is Elvish

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -2679,6 +2679,12 @@ function! s:ExecuteCtags(ctags_cmd) abort
         set shell=sh
     endif
 
+    if &shell =~# 'elvish'
+        " Reset shell since Elvish isn't really compatible
+        let shell_save = &shell
+        set shell=sh
+    endif
+
     if exists('+shellslash')
         let shellslash_save = &shellslash
         set noshellslash


### PR DESCRIPTION
If vim is launched from the Elvish shell, then fall back to using the
bourne shell (sh) or a bourne compatible shell when calling
{universal/exuberant-}ctags.

Signed-off-by: Adam Jimerson <vendion@gmail.com>