### PR TITLE
Test whether &termencoding even exists before use

### DIFF
--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -86,7 +86,7 @@ call s:setup_options()
 
 if !exists('g:tagbar_iconchars')
     if has('multi_byte') && has('unix') && &encoding ==# 'utf-8' &&
-     \ (empty(&termencoding) || &termencoding ==# 'utf-8')
+     \ (!exists('+termencoding') || empty(&termencoding) || &termencoding ==# 'utf-8')
         let g:tagbar_iconchars = ['▶', '▼']
     else
         let g:tagbar_iconchars = ['+', '-']


### PR DESCRIPTION
Fixes #574

See also:

* https://github.com/neovim/neovim/pull/2631
* https://github.com/neovim/neovim/issues/7445
* https://github.com/vim/vim/commit/ac360bf2ca293735fc7c6654dc2b3066f4c62488