### PR TITLE
Fix termencoding check

### DIFF
--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -86,7 +86,7 @@ call s:setup_options()
 
 if !exists('g:tagbar_iconchars')
     if has('multi_byte') && has('unix') && &encoding ==# 'utf-8' &&
-     \ (empty(&termencoding) || &termencoding ==# 'utf-8')
+     \ (!has('termencoding') || empty(&termencoding) || &termencoding ==# 'utf-8')
         let g:tagbar_iconchars = ['▶', '▼']
     else
         let g:tagbar_iconchars = ['+', '-']


### PR DESCRIPTION
Fixes usage in neovim, as this is a dropped option.

Also maybe on Windows, since `vim_diff.txt` in neovim says "Vim 7.4.852 also removed this for Windows".