### PR TITLE
Add g:tagbar_show_balloon option

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -758,7 +758,7 @@ function! s:InitWindow(autoclose) abort
     setlocal nomodifiable
     setlocal textwidth=0
 
-    if has('balloon_eval')
+    if g:tagbar_show_balloon == 1 && has('balloon_eval')
         setlocal balloonexpr=TagbarBalloonExpr()
         set ballooneval
     endif

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -555,6 +555,22 @@ Example:
         let g:tagbar_indent = 1
 <
 
+                                                       *g:tagbar_show_balloon*
+g:tagbar_show_balloon
+Default: 1
+
+Whether balloon messages should be shown in the Tagbar window.
+
+Possible values are:
+  0: Don't show any balloon messages.
+  1: Show balloon messages. This is only available in the GUI when
+     compiled with the |+balloon_eval| feature.
+
+Example:
+>
+        let g:tagbar_show_balloon = 0
+<
+
                                                     *g:tagbar_show_visibility*
 g:tagbar_show_visibility~
 Default: 1

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -67,6 +67,7 @@ function! s:setup_options() abort
         \ ['indent', 2],
         \ ['left', 0],
         \ ['previewwin_pos', previewwin_pos],
+        \ ['show_balloon', 1],
         \ ['show_visibility', 1],
         \ ['show_linenumbers', 0],
         \ ['singleclick', 0],


### PR DESCRIPTION
This adds an option `g:tagbar_show_balloon`, which allows to disable balloon messages.