### PR TITLE
gotags: kinds support ```e:embedded``` and ```w:fields```

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -196,6 +196,8 @@ function! s:InitTypes() abort
             \ {'short' : 'v', 'long' : 'variables',    'fold' : 0, 'stl' : 0},
             \ {'short' : 't', 'long' : 'types',        'fold' : 0, 'stl' : 0},
             \ {'short' : 'n', 'long' : 'intefaces',    'fold' : 0, 'stl' : 0},
+            \ {'short' : 'w', 'long' : 'fields',       'fold' : 0, 'stl' : 0},
+            \ {'short' : 'e', 'long' : 'embedded',     'fold' : 0, 'stl' : 0},
             \ {'short' : 'm', 'long' : 'methods',      'fold' : 0, 'stl' : 0},
             \ {'short' : 'r', 'long' : 'constructors', 'fold' : 0, 'stl' : 0},
             \ {'short' : 'f', 'long' : 'functions',    'fold' : 0, 'stl' : 0},


### PR DESCRIPTION
fix Unknown tag kind encountered: "e".