### PR TITLE
possible bug adding a new filename to _files dictionary

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -663,8 +663,8 @@ endfunction
 " s:known_files.put() {{{2
 " Optional second argument is the filename
 function! s:known_files.put(fileinfo, ...) abort dict
-    if a:0 == 1
-        let self._files[a:1] = a:fileinfo
+    if a:0 == 2
+        let self._files[a:2] = a:fileinfo
     else
         let fname = a:fileinfo.fpath
         let self._files[fname] = a:fileinfo

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -2489,7 +2489,7 @@ function! s:AutoUpdate(fname, force, ...) abort
 
     " Whether we want to skip actually displaying the tags in Tagbar and only
     " update the fileinfo
-    let no_display = a:0 > 0 ? a:1 : 0
+    let no_display = a:0 > 2 ? a:3 : 0
 
     " This file is being loaded due to a quickfix command like vimgrep, so
     " don't process it


### PR DESCRIPTION
If I understood correctly the logic, this bug is rather critical since fileinfo is used as dictionary index intead of the filename. Anyway I can not prove it is related to #558.