### PR TITLE
ProcessFile should not process an unloaded nor an unexisting buffer

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1148,13 +1148,13 @@ function! s:ProcessFile(fname, ftype) abort
         return
     endif
 
-    let bufnum = bufnr(a:fname)
+    let l:bufnum = bufnr(a:fname)
 
-    if !bufloaded(bufnum)
+    if !bufloaded(l:bufnum)
         call tagbar#debug#log('[ProcessFile] Buffer is not loaded exiting...')
         return
     endif
-    if !bufexists(bufnum)
+    if !bufexists(l:bufnum)
         call tagbar#debug#log('[ProcessFile] Buffer does not exist exiting...')
         return
     endif

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1148,6 +1148,17 @@ function! s:ProcessFile(fname, ftype) abort
         return
     endif
 
+    let bufnum = bufnr(a:fname)
+
+    if !bufloaded(bufnum)
+        call tagbar#debug#log('[ProcessFile] Buffer is not loaded exiting...')
+        return
+    endif
+    if !bufexists(bufnum)
+        call tagbar#debug#log('[ProcessFile] Buffer does not exist exiting...')
+        return
+    endif
+
     let typeinfo = s:known_types[a:ftype]
 
     " If the file has only been updated preserve the fold states, otherwise


### PR DESCRIPTION
If buffer is not loaded or does not exist, exit from ProcessFile function, since
in this case getbufline function would return an empty list, thus creating a void file
to be processed for tags extraction. This patch fixes issue #558.