### PR TITLE
tagbar did not play nicely with popup windows

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -3371,6 +3371,18 @@ endfunction
 
 " s:goto_win() {{{2
 function! s:goto_win(winnr, ...) abort
+    "Do not go to a popup window to avoid errors.
+    "Hence, check first if a:winnr is an integer,
+    "if this integer is equal to 0,
+    "the window is a popup window
+    if has('popupwin')
+        if type(a:winnr) == type(0) && a:winnr == 0
+            return
+        endif
+        if a:winnr == 'p' && winnr('#') == 0
+            return
+        endif
+    endif
     let cmd = type(a:winnr) == type(0) ? a:winnr . 'wincmd w'
                                      \ : 'wincmd ' . a:winnr
     let noauto = a:0 > 0 ? a:1 : 0

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -3379,7 +3379,7 @@ function! s:goto_win(winnr, ...) abort
         if type(a:winnr) == type(0) && a:winnr == 0
             return
         endif
-        if a:winnr == 'p' && winnr('#') == 0
+        if a:winnr ==# 'p' && winnr('#') == 0
             return
         endif
     endif


### PR DESCRIPTION
open tagbar and after that open the fzf  popup window (I am assuming fzf.vim plugin
is installed), e.g. with

```vim
:History
```
after you have closed the popup window you get the vim error

```text
not allowed to enter a popup window
```

since tagbar attempts to switch to the popup window through the function
goto_win() but this is forbidden. This patch solves this issue by
checking that the winid of the window tagbar is switching to is not a popup window
