### PR TITLE
window local tagbar

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -888,9 +888,18 @@ function! s:OpenWindow(flags) abort
         let openpos = g:tagbar_left ? 'leftabove ' : 'rightbelow '
         let width = g:tagbar_vertical
     endif
+
+    let l:splitright = &splitright
+    if g:tagbar_window_local == 1
+        let openpos = ''
+        let &splitright = g:tagbar_left ? 0 : 1
+    endif
+
     exe 'silent keepalt ' . openpos . mode . width . 'split ' . s:TagbarBufName()
     exe 'silent ' . mode . 'resize ' . width
     unlet s:window_opening
+
+    let &splitright = l:splitright
 
     call s:InitWindow(autoclose)
 


### PR DESCRIPTION
adds a global option to allow keeping tagbar local to the window containing the buffer

This is draft pull request.

The intention is to keep the tagbar local to the current window. This change does do that.
However if we move to another window while tagbar is active the tagbar will be updated to reflect the buffer in the active window.

I would like to do the following when switching windows with tagbar active (if the opted in)

prevent tagbar being updated when moving around windows
make TagbarToggle close the active tagbar and reopen it in the newly active window
I am very new to vimscript. I would appreciate some hints to be able to do that.