### PR TITLE
Add more flexible options for window positioning.

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -879,14 +879,21 @@ function! s:OpenWindow(flags) abort
     endif
 
     let s:window_opening = 1
-    if g:tagbar_vertical == 0
+    if g:tagbar_position =~# '\v(bottom|right)'
+        let openpos = 'rightbelow '
+    else
+        let openpos = 'leftabove '
+    endif
+    if g:tagbar_position =~# '\v(left|right)'
         let mode = 'vertical '
-        let openpos = g:tagbar_left ? 'topleft ' : 'botright '
         let width = g:tagbar_width
     else
         let mode = ''
-        let openpos = g:tagbar_left ? 'leftabove ' : 'rightbelow '
-        let width = g:tagbar_vertical
+        if g:tagbar_height > 0
+            let width = g:tagbar_height
+        else
+            let width = g:tagbar_vertical
+        endif
     endif
     exe 'silent keepalt ' . openpos . mode . width . 'split ' . s:TagbarBufName()
     exe 'silent ' . mode . 'resize ' . width
@@ -2287,7 +2294,7 @@ function! s:ShowInPreviewWin() abort
     " We want the preview window to be relative to the file window in normal
     " (horizontal) mode, and relative to the Tagbar window in vertical mode,
     " to make the best use of space.
-    if g:tagbar_vertical == 0
+    if g:tagbar_position !~# '\v(top|bottom)'
         call s:GotoFileWindow(taginfo.fileinfo, 1)
         call s:mark_window()
     endif
@@ -2298,7 +2305,7 @@ function! s:ShowInPreviewWin() abort
         silent execute
             \ g:tagbar_previewwin_pos . ' pedit ' .
             \ fnameescape(taginfo.fileinfo.fpath)
-        if g:tagbar_vertical != 0
+        if g:tagbar_position =~# '\v(top|bottom)'
             silent execute 'vertical resize ' . g:tagbar_width
         endif
         " Remember that the preview window was opened by Tagbar so we can
@@ -2306,7 +2313,7 @@ function! s:ShowInPreviewWin() abort
         let s:pwin_by_tagbar = 1
     endif
 
-    if g:tagbar_vertical != 0
+    if g:tagbar_position =~# '\v(top|bottom)'
         call s:GotoFileWindow(taginfo.fileinfo, 1)
         call s:mark_window()
     endif
@@ -2946,6 +2953,7 @@ function! s:ExecuteCtags(ctags_cmd) abort
     else
         let py_version = get(g:, 'tagbar_python', 1)
         silent let ctags_output = s:run_system(a:ctags_cmd, py_version)
+        redraw!
     endif
 
     if &shell =~? 'cmd\.exe'
@@ -3199,7 +3207,7 @@ endfunction
 " s:SetStatusLine() {{{2
 function! s:SetStatusLine() abort
     let tagbarwinnr = bufwinnr(s:TagbarBufName())
-    if tagbarwinnr == -1
+    if tagbarwinnr == -1 || exists('g:tagbar_no_status_line')
         return
     endif
 

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -184,7 +184,7 @@ There are essentially two ways to use Tagbar:
 Opening and closing the Tagbar window~
 Use |:TagbarOpen| or |:TagbarToggle| to open the Tagbar window if it is
 closed. By default the window is opened on the right side, set the option
-|g:tagbar_left| to open it on the left instead. If the window is already open,
+|g:tagbar_position| to open it elsewhere instead. If the window is already open,
 |:TagbarOpen| will jump to it and |:TagbarToggle| will close it again.
 |:TagbarClose| will simply close the window if it is open.
 
@@ -426,9 +426,33 @@ This causes ctags to use settings from ~/.vim/ctags.cnf, ignoring other
 configuration files.
 
 
+                                                           *g:tagbar_position*
+g:tagbar_position~
+Default: 'right'
+
+By default the Tagbar window will be opened on the right-hand side of vim. Set
+this option to one of 'left', 'right', 'bottom', or 'top' to open in the
+corresponding position instead. This can be useful when activating Tagbar at
+the same time as another plugin which creates a new window. It allows for more
+granular control of the Tagbar position in relation to the current active
+window.
+
+If set to 'top' of 'bottom', |g:tagbar_height| will be used to determine the
+window height for the tagbar window.
+
+if set to 'left' or 'right', |g:tagbar_width| will be used to determine the
+window width for the tagbar window.
+
+Example:
+>
+        let g:tagbar_position = 'left'
+<
                                                                *g:tagbar_left*
 g:tagbar_left~
 Default: 0
+
+This option has been superceded by |g:tagbar_position| instead. It has been left
+around for backward compatibility.
 
 By default the Tagbar window will be opened on the right-hand side of vim. Set
 this option to open it on the left instead.
@@ -445,6 +469,9 @@ Example:
 g:tagbar_vertical~
 Default: 0
 
+This option has been superceded by |g:tagbar_height| instead. It has been left
+around for backward compatibility.
+
 If this is set to a positive value then the Tagbar window will be opened at
 the top or bottom of the Vim window instead of at the side. This can be useful
 for monitors that have been rotated into a vertical position. The value of
@@ -456,11 +483,24 @@ Example:
         let g:tagbar_vertical = 30
 <
 
+                                                             *g:tagbar_height*
+g:tagbar_height~
+Default: 0
+
+If |g:tagbar_position| is set to 'bottom' or 'top', then this value is used to
+determine the height of the Tagbar window.
+See |g:tagbar_left| for configuring the position of the window.
+
+Example:
+>
+        let g:tagbar_height = 30
+<
                                                               *g:tagbar_width*
 g:tagbar_width~
 Default: 40
 
-Width of the Tagbar window in characters.
+If |g:tagbar_position| is set to 'left' or 'right', then this value is used to
+determine the width of the Tagbar window in characters.
 
 Example:
 >
@@ -778,6 +818,19 @@ default statusline:
         endfunction
         let g:tagbar_status_func = 'TagbarStatusFunc'
 <
+                                                     *g:tagbar_no_status_line*
+g:no_status_line~
+Default: undefined
+
+This option will prevent any status line updates being done by Tagbar. Use
+this in the event where another plugin is being used to update the status
+line. If |g:tagbar_status_func| is set, then that function will never be
+called.
+
+Example:
+>
+       let g:no_status_line = 1
+<
 
                                                            *g:tagbar_silent*
 g:tagbar_silent~
@@ -789,6 +842,7 @@ about the tag is echoed out. Set this option to disable that behavior.
 Example:
 >
         let g:tagbar_silent = 1
+<
                                                            *g:tagbar_use_cache*
 g:tagbar_use_cache~
 Default: 1

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -49,10 +49,29 @@ function! s:init_var(var, value) abort
 endfunction
 
 function! s:setup_options() abort
-    if !exists('g:tagbar_vertical') || g:tagbar_vertical == 0
-        let previewwin_pos = 'topleft'
+    if exists('g:tagbar_position')
+        if g:tagbar_position !~# '\v(top|bottom)'
+            let previewwin_pos = 'topleft'
+        else
+            let previewwin_pos = 'rightbelow vertical'
+        endif
+        let default_pos = g:tagbar_position
     else
-        let previewwin_pos = 'rightbelow vertical'
+        if exists('g:tagbar_vertical') && g:tagbar_vertical > 0
+            let previewwin_pos = 'rightbelow vertical'
+            if exists('g:tagbar_left') && g:tagbar_left
+                let default_pos = 'top'
+            else
+                let default_pos = 'bottom'
+            endif
+            let g:tagbar_height = g:tagbar_vertical
+        elseif exists('g:tagbar_left') && g:tagbar_left
+            let previewwin_pos = 'topleft'
+            let default_pos = 'left'
+        else
+            let previewwin_pos = 'topleft'
+            let default_pos = 'right'
+        endif
     endif
     let options = [
         \ ['autoclose', 0],
@@ -64,6 +83,7 @@ function! s:setup_options() abort
         \ ['expand', 0],
         \ ['foldlevel', 99],
         \ ['hide_nonpublic', 0],
+        \ ['height', 10],
         \ ['indent', 2],
         \ ['left', 0],
         \ ['previewwin_pos', previewwin_pos],
@@ -74,6 +94,7 @@ function! s:setup_options() abort
         \ ['sort', 1],
         \ ['systemenc', &encoding],
         \ ['vertical', 0],
+        \ ['position', default_pos],
         \ ['width', 40],
         \ ['zoomwidth', 1],
         \ ['silent', 0],


### PR DESCRIPTION
New configuration option for g:tagbar_position that will supercede g:tagbar_left. This option allows for new values for 'top', 'bottom', 'left' and 'right' (default:'right') to position the Tagbar window.

New configuration option for g:tagbar_height that will supercede g:tagbar_vertical. This option is used to set the Tagbar window height when the window is split using the 'top' or 'bottom' position.

New configuration option for g:tagbar_no_status_line. This option will disable any Tagbar status line updates in the event another plugin is controlling the status line. This prevents Tagbar from changing the status line when Tagbar is not the active window.