### PR TITLE
Fix maximized state track on close

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1034,6 +1034,7 @@ function! s:CloseWindow() abort
             " Other windows are open, only close the tagbar one
 
             let curfile = tagbar#state#get_current_file(0)
+            let s:is_maximized = 0
 
             close
 


### PR DESCRIPTION
Fix need of pressing 'x' twice to maximize the Tagbar when it was closed maximized.