### PR TITLE
Fix has_key() parameters in  currenttagtype function.

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -3720,7 +3720,7 @@ function! tagbar#currenttagtype(fmt, default) abort
 
     let typeinfo = tag.fileinfo.typeinfo
     let plural = typeinfo.kinds[typeinfo.kinddict[kind]].long
-    if has_key(plural)
+    if has_key(s:singular_types, plural)
         let singular = s:singular_types[plural]
     else
         let singular = plural


### PR DESCRIPTION
Closes #644.

The idea of unconditionally reaching for particular word in dictionary using plural key was, that in case of missing singular, it vim will complain about it, so that it might be added to the dictionary in next iteration. Currently, it will offer plural as singular which could be easily missed.

Maybe behaviour for particular ctags implementations should be separated, as apparently that was the case in PR #631?