### PR TITLE
Fix --file-scope option warning

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1316,9 +1316,9 @@ function! s:ExecuteCtagsOnFile(fname, realfname, typeinfo) abort
 
         " universal-ctags deprecated this argument name
         if s:ctags_is_uctags
-            let ctags_args += [ '--extras=' ]
+            let ctags_args += [ '--extras=+F' ]
         else
-            let ctags_args += [ '--extra=' ]
+            let ctags_args += [ '--extra=', '--file-scope=yes' ]
         endif
 
         let ctags_args  = ctags_args + [
@@ -1327,7 +1327,6 @@ function! s:ExecuteCtagsOnFile(fname, realfname, typeinfo) abort
                           \ '--format=2',
                           \ '--excmd=pattern',
                           \ '--fields=nksSaf',
-                          \ '--file-scope=yes',
                           \ '--sort=no',
                           \ '--append=no'
                           \ ]


### PR DESCRIPTION
`--file-scope` is removed on universal-ctags.

https://github.com/universal-ctags/ctags/commit/9a46d5eb82a4f6bba26bc3ea7d2abaa0a7956e4c
https://github.com/universal-ctags/ctags/commit/cf82cfa2910c3a6dd5c152b01f6948d113cec647

This PR fixes the warning when calling `:TagbarDebug`

```
  ctags: Warning: "--file-scope" option is obsolete; use "--extras=+F" instead
```