### PR TITLE
Fix issue with jumping to a tag with special characters

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -2250,7 +2250,7 @@ function! s:JumpToTag(stay_in_tagbar) abort
         call cursor(taginfo.fields.line, taginfo.fields.column)
     else
         call cursor(taginfo.fields.line, 1)
-        call search(taginfo.name, 'c', line('.'))
+        call search('\V' . taginfo.name, 'c', line('.'))
     endif
 
     normal! zv


### PR DESCRIPTION
In C++, the name of the destructor of a class starts with a tidle(~) which is special when the option 'magic' is set. This will cause an error when jumping to a destructor. Calling search() in "very nomagic" environment can solve this problem no matter the option 'magic' is set or not.